### PR TITLE
Add `/track/click` endpoint

### DIFF
--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dub/analytics-script",
-  "version": "0.0.6",
+  "version": "0.0.19",
   "main": "src/index.js",
   "scripts": {
     "prebuild": "mkdir -p dist/analytics",

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -38,13 +38,13 @@
     const api = script.getAttribute('data-api');
     const am = script.getAttribute('data-attribution-model');
     const co = script.getAttribute('data-cookie-options');
-    const sp = script.getAttribute('data-search-param');
+    const qp = script.getAttribute('data-query-param');
 
     return {
       api: api || 'https://api.dub.co/track/click',
       attributionModel: am || 'last-click',
       cookieOptions: co ? JSON.parse(co) : null,
-      searchParam: sp || 'ref',
+      queryParam: qp || 'ref',
     };
   }
 
@@ -100,13 +100,13 @@
   // Function to check for { keys } in the URL and update cookie if necessary
   function watchForQueryParams() {
     const searchParams = new URLSearchParams(window.location.search);
-    const { api, cookieOptions, attributionModel, searchParam } =
+    const { api, cookieOptions, attributionModel, queryParam } =
       getOptions(script);
 
     let clickId = searchParams.get(CLICK_ID) || searchParams.get(OLD_CLICK_ID);
 
     if (!clickId) {
-      const identifier = searchParams.get(searchParam);
+      const identifier = searchParams.get(queryParam);
 
       if (identifier) {
         fetch(api, {

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -35,13 +35,13 @@
       return null;
     }
 
-    const api = script.getAttribute('data-api');
+    const ah = script.getAttribute('data-api-host');
     const am = script.getAttribute('data-attribution-model');
     const co = script.getAttribute('data-cookie-options');
     const qp = script.getAttribute('data-query-param');
 
     return {
-      api: api || 'https://api.dub.co/track/click',
+      apiHost: ah || 'https://api.dub.co',
       attributionModel: am || 'last-click',
       cookieOptions: co ? JSON.parse(co) : null,
       queryParam: qp || 'ref',
@@ -100,7 +100,7 @@
   // Function to check for { keys } in the URL and update cookie if necessary
   function watchForQueryParams() {
     const searchParams = new URLSearchParams(window.location.search);
-    const { api, cookieOptions, attributionModel, queryParam } =
+    const { apiHost, cookieOptions, attributionModel, queryParam } =
       getOptions(script);
 
     let clickId = searchParams.get(CLICK_ID) || searchParams.get(OLD_CLICK_ID);
@@ -109,7 +109,7 @@
       const identifier = searchParams.get(queryParam);
 
       if (identifier) {
-        fetch(api, {
+        fetch(`${apiHost}/track/click`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -115,7 +115,6 @@
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            domain: window.location.hostname,
             identifier,
           }),
         }).then((res) => {

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -158,6 +158,13 @@
         return;
       }
 
+      if (res.status === 204) {
+        console.warn(
+          `[Dub Analytics] Link does not exist for identifier: ${identifier}. Click not tracked.`,
+        );
+        return;
+      }
+
       const { clickId } = await res.json(); // Response: { clickId: string }
       checkCookieAndSet(clickId);
     });

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -134,8 +134,8 @@
     }
 
     if (!apiKey) {
-      console.error(
-        '[Dub Analytics] Publishable API key not specified, which is required for tracking clicks. Please set the `apiKey` option.',
+      console.warn(
+        '[Dub Analytics] Matching identifier detected but publishable API key not specified, which is required for tracking clicks. Please set the `apiKey` option, or clicks will not be tracked.',
       );
       return;
     }

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -117,8 +117,16 @@
           body: JSON.stringify({
             identifier,
           }),
-        }).then((res) => {
-          const data = res.json(); // Response: { clickId: string }
+        }).then(async (res) => {
+          if (!res.ok) {
+            const { error } = await res.json();
+            console.error(
+              `[Dub Analytics] Failed to track click: ${error.message}`,
+            );
+            return;
+          }
+
+          const data = await res.json(); // Response: { clickId: string }
 
           clickId = data.clickId;
         });

--- a/packages/script/src/index.js
+++ b/packages/script/src/index.js
@@ -36,12 +36,14 @@
     }
 
     const ah = script.getAttribute('data-api-host');
+    const ak = script.getAttribute('data-api-key');
     const am = script.getAttribute('data-attribution-model');
     const co = script.getAttribute('data-cookie-options');
     const qp = script.getAttribute('data-query-param');
 
     return {
       apiHost: ah || 'https://api.dub.co',
+      apiKey: ak,
       attributionModel: am || 'last-click',
       cookieOptions: co ? JSON.parse(co) : null,
       queryParam: qp || 'ref',
@@ -100,7 +102,7 @@
   // Function to check for { keys } in the URL and update cookie if necessary
   function watchForQueryParams() {
     const searchParams = new URLSearchParams(window.location.search);
-    const { apiHost, cookieOptions, attributionModel, queryParam } =
+    const { apiHost, apiKey, cookieOptions, attributionModel, queryParam } =
       getOptions(script);
 
     let clickId = searchParams.get(CLICK_ID) || searchParams.get(OLD_CLICK_ID);
@@ -109,9 +111,17 @@
       const identifier = searchParams.get(queryParam);
 
       if (identifier) {
+        if (!apiKey) {
+          console.error(
+            '[Dub Analytics] Publishable API key not specified, which is required for tracking clicks. Please set the `apiKey` option.',
+          );
+          return;
+        }
+
         fetch(`${apiHost}/track/click`, {
           method: 'POST',
           headers: {
+            Authorization: `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -36,6 +36,22 @@
 
 You can pass the following props to the `Analytics` component to customize the tracking script.
 
+### `apiHost`
+
+The API host to use for tracking. The default is `https://api.dub.co`.
+
+### `apiKey`
+
+The publishable API key to use for tracking. Get your publishable API key from your [Dub workspace's token settings page](https://app.dub.co/settings/tokens).
+
+### `attributionModel`
+
+Decide the attribution model to use for tracking. The default is `last-click`.
+
+- `first-click` - The first click model gives all the credit to the first touchpoint in the customer journey.
+- `last-click` - The last click model gives all the credit to the last touchpoint in the customer journey.
+
+
 ### `cookieOptions`
 
 The `cookieOptions` prop accepts the following keys:
@@ -61,9 +77,10 @@ import { Analytics as DubAnalytics } from "@dub/analytics"
 />
 ```
 
-### `attributionModel`
+### `queryParam`
 
-Decide the attribution model to use for tracking. The default is `last-click`.
+The query parameter to listen to for client-side click-tracking (e.g. `?ref=abc123`). The default is `ref`.
 
-- `first-click` - The first click model gives all the credit to the first touchpoint in the customer journey.
-- `last-click` - The last click model gives all the credit to the last touchpoint in the customer journey.
+### `scriptProps`
+
+Custom properties to pass to the script tag. Refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement) for all available options.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dub/analytics",
-  "version": "0.0.18",
+  "version": "0.0.18-beta.4",
   "description": "",
   "keywords": [
     "analytics",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dub/analytics",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "keywords": [
     "analytics",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dub/analytics",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "keywords": [
     "analytics",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dub/analytics",
-  "version": "0.0.18-beta.4",
+  "version": "0.0.18",
   "description": "",
   "keywords": [
     "analytics",

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -33,8 +33,8 @@ function inject(props: AnalyticsProps): void {
     );
   }
 
-  if (props.searchParam) {
-    script.setAttribute('data-search-param', props.searchParam);
+  if (props.queryParam) {
+    script.setAttribute('data-query-param', props.queryParam);
   }
 
   if (props.scriptProps) {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -18,8 +18,8 @@ function inject(props: AnalyticsProps): void {
   script.setAttribute('data-sdkn', name);
   script.setAttribute('data-sdkv', version);
 
-  if (props.api) {
-    script.setAttribute('data-api', props.api);
+  if (props.apiHost) {
+    script.setAttribute('data-api-host', props.apiHost);
   }
 
   if (props.attributionModel) {

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -2,19 +2,20 @@ import { name, version } from '../package.json';
 import type { AnalyticsProps } from './types';
 import { isBrowser } from './utils';
 
-const src = 'https://www.dubcdn.com/analytics/script.js';
-
 /**
  * Injects the Dub Web Analytics script into the page head.
  */
 function inject(props: AnalyticsProps): void {
   if (!isBrowser()) return;
 
+  const src =
+    props.scriptProps?.src || 'https://www.dubcdn.com/analytics/script.js';
+
   if (document.head.querySelector(`script[src*="${src}"]`)) return;
 
   const script = document.createElement('script');
   script.src = src;
-  script.defer = true;
+  script.defer = props.scriptProps?.defer || true;
   script.setAttribute('data-sdkn', name);
   script.setAttribute('data-sdkv', version);
 

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -23,6 +23,10 @@ function inject(props: AnalyticsProps): void {
     script.setAttribute('data-api-host', props.apiHost);
   }
 
+  if (props.apiKey) {
+    script.setAttribute('data-api-key', props.apiKey);
+  }
+
   if (props.attributionModel) {
     script.setAttribute('data-attribution-model', props.attributionModel);
   }

--- a/packages/web/src/generic.ts
+++ b/packages/web/src/generic.ts
@@ -18,8 +18,13 @@ function inject(props: AnalyticsProps): void {
   script.setAttribute('data-sdkn', name);
   script.setAttribute('data-sdkv', version);
 
-  // TODO:
-  // Merge the cookieOptions and attributionModel into options
+  if (props.api) {
+    script.setAttribute('data-api', props.api);
+  }
+
+  if (props.attributionModel) {
+    script.setAttribute('data-attribution-model', props.attributionModel);
+  }
 
   if (props.cookieOptions && Object.keys(props.cookieOptions).length > 0) {
     script.setAttribute(
@@ -28,8 +33,12 @@ function inject(props: AnalyticsProps): void {
     );
   }
 
-  if (props.attributionModel) {
-    script.setAttribute('data-attribution-model', props.attributionModel);
+  if (props.searchParam) {
+    script.setAttribute('data-search-param', props.searchParam);
+  }
+
+  if (props.scriptProps) {
+    Object.assign(script, props.scriptProps);
   }
 
   script.onerror = (): void => {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -3,9 +3,9 @@ export type AllowedPropertyValues = string | number | boolean | null;
 export interface AnalyticsProps {
   /**
    * The API endpoint to send analytics data to.
-   * @default 'https://api.dub.co/track/click'
+   * @default 'https://api.dub.co'
    */
-  api?: string;
+  apiHost?: string;
 
   /**
    * The Attribution Model to use for the analytics event.

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -1,11 +1,32 @@
 export type AllowedPropertyValues = string | number | boolean | null;
 
 export interface AnalyticsProps {
+  /**
+   * The API endpoint to send analytics data to.
+   * @default 'https://api.dub.co/track/click'
+   */
+  api?: string;
+
+  /**
+   * The Attribution Model to use for the analytics event.
+   *
+   * @default 'last-click'
+   *
+   * - `first-click` - The first click model gives all the credit to the first touchpoint in the customer journey.
+   * - `last-click` - The last click model gives all the credit to the last touchpoint in the customer journey.
+   */
+  attributionModel?: 'first-click' | 'last-click';
+
+  /**
+   * The cookie options to use for the analytics event.
+   */
   cookieOptions?: {
     /**
      * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.3|Domain Set-Cookie attribute}. By default, no
-     * domain is set, and most clients will consider the cookie to apply to only
-     * the current domain.
+     * domain is set, and most clients will consider the cookie to apply to only the current domain.
+     * By default, the domain is set to the current hostname (including all subdomains).
+     *
+     * @default `.` + window.location.hostname
      */
     domain?: string | undefined;
 
@@ -87,14 +108,20 @@ export interface AnalyticsProps {
   };
 
   /**
-   * The Attribution Model to use for the analytics event.
+   * The search parameter to listen to for client-side click-tracking (e.g. `?ref=abc123`)
    *
-   * @default 'last-click'
-   *
-   * - `first-click` - The first click model gives all the credit to the first touchpoint in the customer journey.
-   * - `last-click` - The last click model gives all the credit to the last touchpoint in the customer journey.
+   * @default 'ref'
    */
-  attributionModel?: 'first-click' | 'last-click';
+  searchParam?: string;
+
+  /**
+   * Custom properties to pass to the script.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement
+   */
+  scriptProps?: React.DetailedHTMLProps<
+    React.ScriptHTMLAttributes<HTMLScriptElement>,
+    HTMLScriptElement
+  >;
 }
 
 export interface ClickApiResponse {

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -108,11 +108,11 @@ export interface AnalyticsProps {
   };
 
   /**
-   * The search parameter to listen to for client-side click-tracking (e.g. `?ref=abc123`)
+   * The query parameter to listen to for client-side click-tracking (e.g. `?ref=abc123`)
    *
    * @default 'ref'
    */
-  searchParam?: string;
+  queryParam?: string;
 
   /**
    * Custom properties to pass to the script.

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -8,6 +8,12 @@ export interface AnalyticsProps {
   apiHost?: string;
 
   /**
+   * The publishable API key to use for tracking click events.
+   * @example 'dub_publishable_xxxxxxxxxx'
+   */
+  apiKey?: string;
+
+  /**
    * The Attribution Model to use for the analytics event.
    *
    * @default 'last-click'


### PR DESCRIPTION
Also simplifies the cookie to be set on the subdomain by default (e.g. `.dub.co`)