### PR TITLE
Add wildcard support to outbound-domains

### DIFF
--- a/apps/nextjs/app/layout.tsx
+++ b/apps/nextjs/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
         domainsConfig={{
           refer: 'getacme.link',
           site: 'getacme.link',
-          outbound: 'example.com,other.com,sub.example.com',
+          outbound: 'example.com,other.com,sub.example.com,*.wildcard.com',
         }}
         scriptProps={{
           src: DUB_ANALYTICS_SCRIPT_URL,

--- a/apps/nextjs/app/outbound/page.tsx
+++ b/apps/nextjs/app/outbound/page.tsx
@@ -15,6 +15,15 @@ export default function Outbound() {
       <a href="https://sub.example.com">Subdomain Link</a>
       <a href="https://other.example.com">Other Subdomain Link</a>
       <a href="https://www.sub.example.com">WWW Subdomain Link</a>
+
+      {/* Wildcard domain test links */}
+      <a href="https://api.wildcard.com">Wildcard API Link</a>
+      <a href="https://admin.wildcard.com">Wildcard Admin Link</a>
+      <a href="https://deep.nested.wildcard.com">Wildcard Nested Link</a>
+      <a href="https://wildcard.com">Wildcard Root Link</a>
+      <a href="https://notwildcard.com">Non-Wildcard Link</a>
+      <a href="https://www.api.wildcard.com">WWW Wildcard API Link</a>
+      <a href="https://www.admin.wildcard.com">WWW Wildcard Admin Link</a>
     </div>
   );
 }

--- a/packages/script/src/extensions/outbound-domains.js
+++ b/packages/script/src/extensions/outbound-domains.js
@@ -18,9 +18,10 @@ const initOutboundDomains = () => {
       const normalizedUrlHostname = normalizeDomain(urlHostname);
       const normalizedDomain = normalizeDomain(domain);
 
-      // if wildcard domain, check if the url hostname ends with the domain
+      // if wildcard domain, check if the url hostname ends with the apex domain
       if (normalizedDomain.startsWith('*.')) {
-        return normalizedUrlHostname.endsWith(normalizedDomain.slice(2));
+        const apexDomain = normalizedDomain.slice(2);
+        return normalizedUrlHostname.endsWith(`.${apexDomain}`);
       }
 
       // check for exact match after removing www.

--- a/packages/script/src/extensions/outbound-domains.js
+++ b/packages/script/src/extensions/outbound-domains.js
@@ -18,7 +18,12 @@ const initOutboundDomains = () => {
       const normalizedUrlHostname = normalizeDomain(urlHostname);
       const normalizedDomain = normalizeDomain(domain);
 
-      // Exact match after removing www.
+      // if wildcard domain, check if the url hostname ends with the domain
+      if (normalizedDomain.startsWith('*.')) {
+        return normalizedUrlHostname.endsWith(normalizedDomain.slice(2));
+      }
+
+      // check for exact match after removing www.
       return normalizedUrlHostname === normalizedDomain;
     } catch (e) {
       return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Outbound link tracking now supports wildcard domains (e.g., *.wildcard.com), including handling of www-prefixed subdomains.
  - Outbound demo page includes sample links to validate wildcard and non-wildcard behavior.

- Tests
  - Added tests verifying tracking parameters are applied to wildcard domains and ignored for non-matching domains.
  - Added tests confirming correct handling of www-prefixed wildcard subdomains.
  - Removed an unused import in the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->