### PR TITLE
Support outbound-domains for iframes with srcdoc

### DIFF
--- a/apps/nextjs/app/outbound/page.tsx
+++ b/apps/nextjs/app/outbound/page.tsx
@@ -8,6 +8,10 @@ export default function Outbound() {
       <iframe src="https://example.com/embed"></iframe>
       <iframe src="https://www.example.com/embed"></iframe>
 
+      {/* Cal.com style iframe with srcdoc */}
+      <iframe srcdoc='<html><body><h1>Cal.com Embed</h1><a href="https://example.com/booking">Book Now</a><script src="https://other.com/widget.js"></script></body></html>'></iframe>
+      <iframe srcdoc='<div>Another srcdoc iframe with <a href="https://wildcard.com/test">link</a></div>'></iframe>
+
       <a href="https://getacme.link/about">Internal Link</a>
       <div id="container"></div>
 

--- a/apps/nextjs/app/outbound/page.tsx
+++ b/apps/nextjs/app/outbound/page.tsx
@@ -8,9 +8,9 @@ export default function Outbound() {
       <iframe src="https://example.com/embed"></iframe>
       <iframe src="https://www.example.com/embed"></iframe>
 
-      {/* Cal.com style iframe with srcdoc */}
-      <iframe srcdoc='<html><body><h1>Cal.com Embed</h1><a href="https://example.com/booking">Book Now</a><script src="https://other.com/widget.js"></script></body></html>'></iframe>
-      <iframe srcdoc='<div>Another srcdoc iframe with <a href="https://wildcard.com/test">link</a></div>'></iframe>
+      {/* Cal.com style iframe with srcdoc containing nested iframes */}
+      <iframe srcdoc='<html><body><h1>Cal.com Embed</h1><iframe src="https://example.com/booking-widget"></iframe><iframe src="https://other.com/calendar"></iframe></body></html>'></iframe>
+      <iframe srcdoc='<div>Another srcdoc with nested content<iframe src="https://wildcard.com/scheduler"></iframe></div>'></iframe>
 
       <a href="https://getacme.link/about">Internal Link</a>
       <div id="container"></div>


### PR DESCRIPTION
Extend outbound domain tracking to handle iframes with srcdoc attributes, such as those used by Cal.com. The script now detects and updates URLs within srcdoc content to append the tracking parameter. Corresponding tests and example usage have been added to ensure correct behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound tracking support for srcdoc-based iframes (including nested embeds like Cal.com-style), appending tracking parameters to embedded URLs.
  * Expanded coverage beyond standard links and iframe src attributes for more reliable tracking.
* **Tests**
  * Added end-to-end test validating tracking injection within srcdoc-based nested iframes.
* **Chores**
  * Updated outbound demo page to include example srcdoc iframes for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->